### PR TITLE
Fixes for A18

### DIFF
--- a/Mods/Home_Depot/Config/blocks.xml
+++ b/Mods/Home_Depot/Config/blocks.xml
@@ -308,7 +308,7 @@
 			<property name="Extends" value="Home Campfire Helper"/>
 			<property name="CustomIcon" value="cntGasGrillOpen"/>
 			<property name="Shape" value="ModelEntity"/>
-			<property name="Model" value="Entities/LootContainers/GasGrill_EmptyPrefab"/>
+			<property name="Model" value="#Entities/LootContainers?GasGrill_EmptyPrefab.prefab"/>
 			<property name="Path" value="solid"/>
 			<property name="Place" value="TowardsPlacerInverted"/>
 			<property name="EconomicValue" value="244"/>
@@ -317,7 +317,7 @@
 			<property name="Extends" value="Home Campfire Helper"/>
 			<property name="CustomIcon" value="cntGasGrillClosed"/>
 			<property name="Shape" value="ModelEntity"/>
-			<property name="Model" value="Entities/LootContainers/GasGrill_FullPrefab"/>
+			<property name="Model" value="#Entities/LootContainers?GasGrill_FullPrefab.prefab"/>
 			<property name="Path" value="solid"/>
 			<property name="Place" value="TowardsPlacerInverted"/>
 			<property name="EconomicValue" value="244"/>
@@ -326,7 +326,7 @@
 			<property name="Extends" value="Home Campfire Helper"/>
 			<property name="CustomIcon" value="cntCharcoalGrillOpen"/>
 			<property name="Shape" value="ModelEntity"/>
-			<property name="Model" value="Entities/LootContainers/Grill_Simple_EmptyPrefab"/>
+			<property name="Model" value="#Entities/LootContainers?Grill_Simple_EmptyPrefab.prefab"/>
 			<property name="Path" value="solid"/>
 			<property name="Place" value="TowardsPlacer90"/>
 			<property name="EconomicValue" value="244"/>
@@ -335,7 +335,7 @@
 			<property name="Extends" value="Home Campfire Helper"/>
 			<property name="CustomIcon" value="cntCharcoalGrillClosed"/>
 			<property name="Shape" value="ModelEntity"/>
-			<property name="Model" value="Entities/LootContainers/Grill_Simple_ClosedPrefab"/>
+			<property name="Model" value="#Entities/LootContainers?Grill_Simple_ClosedPrefab.prefab"/>
 			<property name="Path" value="solid"/>
 			<property name="Place" value="TowardsPlacer90"/>
 			<property name="EconomicValue" value="244"/>
@@ -379,7 +379,7 @@
 			<property name="Extends" value="Home Watersource Helper"/>
 			<property name="CustomIcon" value="wallHungSink"/>
 			<property name="Shape" value="ModelEntity"/>
-			<property name="Model" value="Entities/Plumbing/wall_hung_sinkPrefab"/>
+			<property name="Model" value="#Entities/LootContainers?wallHungSinkPrefab.prefab"/>
 			<property name="ImposterExclude" value="true"/>
 			<property name="EconomicValue" value="144"/>
 			<drop event="Destroy" name="Home Wall Sink" count="1" prob="1"/>
@@ -425,7 +425,7 @@
 			<property name="Extends" value="Home Watersource Helper"/>
 			<property name="CustomIcon" value="cntWaterCoolerFull"/>
 			<property name="Shape" value="ModelEntity"/>
-			<property name="Model" value="Entities/LootContainers/water_cooler_fullPrefab" />
+			<property name="Model" value="#Entities/LootContainers?water_cooler_fullPrefab.prefab" />
 			<property name="StabilitySupport" value="false"/>
 			<property name="DisplayType" value="blockMulti" />
 			<property name="MultiBlockDim" value="1,2,1"/>

--- a/Mods/Home_Depot/Config/items.xml
+++ b/Mods/Home_Depot/Config/items.xml
@@ -3,6 +3,7 @@
 	ADD WORKING APPLIANCES
 	================================ -->
 	<!-- New Water Sources Fill Containers -->
+	<!--
 	<append xpath="/items/item[@name='drinkCanEmpty']/property[@class='Action1']">
 		<property name="Focused_blockname_6" value="Home Utility Sink"/>
 		<property name="Focused_blockname_7" value="Home Wall Sink"/>
@@ -10,6 +11,7 @@
 		<property name="Focused_blockname_9" value="Home Granite Sink"/>
 		<property name="Focused_blockname_10" value="Home Fountain"/>
 	</append>
+-->
 	<append xpath="/items/item[@name='drinkJarEmpty']/property[@class='Action1']">
 		<property name="Focused_blockname_6" value="Home Utility Sink"/>
 		<property name="Focused_blockname_7" value="Home Wall Sink"/>

--- a/Mods/Home_Depot/Config/progression.xml
+++ b/Mods/Home_Depot/Config/progression.xml
@@ -23,7 +23,7 @@
 	</append>
 
 	<!-- Include Home Woodstove & All Home Grill Recipes (Locked behind HammerForge 1) -->
-	<append xpath="/progression/perks/perk[@name='perkHammerForge']/effect_group">
+	<append xpath="/progression/perks/perk[@name='perkAdvancedEngineering']/effect_group">
 		<passive_effect name="RecipeTagUnlocked" operation="base_set" value="1" level="1,5" tags="Home Woodstove,Home Gas Grill Open,Home Gas Grill Closed,Home Charcoal Grill Open,Home Charcoal Grill Closed"/>
 		<passive_effect name="RecipeTagUnlocked" operation="base_set" value="1" level="1,5" tags="roadRailing,roadRailingPole,roadRailingEnd,roadRailingEnd2,chainLink,chainLinkFenceBottomPole,chainLinkFenceTop,chainLinkFenceTopPole,chainLinkPole,chainLinkCornerTop,chainLinkCornerBottom,chainLinkFenceTopPole2"/>
 	</append>

--- a/Mods/Home_Depot/Config/recipes.xml
+++ b/Mods/Home_Depot/Config/recipes.xml
@@ -177,6 +177,7 @@
 			<ingredient name="resourceWood" count="6"/>
 		</recipe>
 
+<!--
 		<recipe name="decoPillarRoundCentered" count="1" craft_area="tablesaw">
 			<ingredient name="resourceWood" count="10"/>
 			<ingredient name="resourceNail" count="5"/>
@@ -185,6 +186,7 @@
 			<ingredient name="resourceWood" count="10"/>
 			<ingredient name="resourceNail" count="5"/>
 		</recipe>
+	-->
 
 		<recipe name="roadRailing" count="1" craft_area="forge" craft_tool="toolAnvil" material_based="true" tags="learnable">
 			<ingredient name="unit_iron" count="50"/>
@@ -293,9 +295,17 @@
 	?FIX Any other strange Requirements of Perks/Attributes
 	================================ -->
 	<!-- Existing recipes that should have required tablesaw -->
-	<setattribute xpath="/recipes/recipe[@name='cntCabinetBottom']" name="craft_area">tablesaw</setattribute>
-	<setattribute xpath="/recipes/recipe[@name='cntCupboardCabinetRedTopClosed']" name="craft_area">tablesaw</setattribute>
-
+	<append xpath="/recipes">
+		<recipe name="cntCabinetBottom" count="1" craft_time="4" craft_area="tablesaw" tags="learnable,tableSawCrafting">
+			<ingredient name="resourceGlue" count="2" />
+			<ingredient name="resourceWood" count="10" />		
+		</recipe>
+		<recipe name="cntCupboardCabinetRedTopClosed" count="1" craft_time="4" craft_area="tablesaw" tags="learnable,tableSawCrafting">
+			<ingredient name="resourceGlue" count="2" />
+			<ingredient name="resourceWood" count="10" />		
+		</recipe>
+	</append>
+	
 	<!-- Include Snowberry Recipe (Locked behind LivingOffTheLand 3) -->
 	<append xpath="/recipes">
 		<recipe name="plantedSnowberry1" count="1" craft_time="4" tags="learnable">


### PR DESCRIPTION
I really wanted to use your Modlet, so I took the time to convert as much of it over to A18 as I could. Empty Cans can no longer be used to fill from water sources, as best as I could tell, so that is commented out in the code. And Deco Pillars I wasn't able to locate in the vanilla code, so I commented out two recipes. There were some Model Prefabs that I converted over to the A18 format. And one perk that no longer existed I converted over to Advanced Engineering, which seemed like the next closest.