### PR TITLE
Compatibility with A19 EXPERIMENTAL  - removal of blood draw kit recipe

### DIFF
--- a/Mods/Home_Depot/Config/recipes.xml
+++ b/Mods/Home_Depot/Config/recipes.xml
@@ -313,15 +313,6 @@
 		</recipe>
 	</append>
 
-	<!-- Include BloodDrawKit Recipe (Locked behind Physician 3) -->
-	<append xpath="/recipes">
-		<recipe name="medicalBloodDrawKit" count="1" craft_time="90" tags="learnable">
-			<ingredient name="resourceScrapPolymers" count="8"/>
-			<ingredient name="medicalBandage" count="1"/>
-			<ingredient name="resourceGlue" count="2"/>
-		</recipe>
-	</append>
-
 	<!-- Change actual Vehicles to require GreaseMonkey (not just vehicle parts) -->
 	<setattribute xpath="/recipes/recipe[@name='vehicleBicyclePlaceable']" name="tags">learnable</setattribute>
 	<setattribute xpath="/recipes/recipe[@name='vehicleMinibikePlaceable']" name="tags">learnable</setattribute>


### PR DESCRIPTION
Upon starting a new server with A19 EXPERIMENTAL b154 the item medicalBloodDrawKit was not found. This update removes the recipe for that item so the mod does not break the build. 

Recommend possibly looking into what item it is replaced by (if any) in the future. Will PR that change once I get into the files a bit more. 